### PR TITLE
ToString => ToDebugString. Fixes marshaling which by mistake used the…

### DIFF
--- a/es/common.go
+++ b/es/common.go
@@ -116,7 +116,7 @@ func KeyValuesToValues(t string, typedUIDs []string) ([]string, error) {
 	return ret, nil
 }
 
-func (result *Result) ToString() string {
+func (result *Result) ToDebugString() string {
 	resultCopy := result
 	if len(resultCopy.Content) > 30 {
 		resultCopy.Content = fmt.Sprintf("%s...", resultCopy.Content[:30])

--- a/es/content_units_index.go
+++ b/es/content_units_index.go
@@ -364,7 +364,7 @@ func (index *ContentUnitsIndex) indexUnit(cu *mdbmodels.ContentUnit, indexData *
 	for k, v := range i18nMap {
 		name := index.indexName(k)
 
-		log.Infof("Content Units Index - Add content unit %s to index %s", v.ToString(), name)
+		log.Infof("Content Units Index - Add content unit %s to index %s", v.ToDebugString(), name)
 		resp, err := index.esc.Index().
 			Index(name).
 			Type("result").

--- a/es/tags_index.go
+++ b/es/tags_index.go
@@ -133,7 +133,7 @@ func (index *TagsIndex) indexTag(t *mdbmodels.Tag) error {
 				TitleSuggest: Suffixes(strings.Join(pathNames, " ")),
 			}
 			name := index.indexName(i18n.Language)
-			log.Infof("Tags Index - Add tag %s to index %s", r.ToString(), name)
+			log.Infof("Tags Index - Add tag %s to index %s", r.ToDebugString(), name)
 			resp, err := index.esc.Index().
 				Index(name).
 				Type("result").


### PR DESCRIPTION
… ToString which truncated content.