### PR TITLE
1. Keep order of returned CUs exactly the same as requested

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -2355,10 +2355,25 @@ func mdbToBlogPost(post *mdbmodels.BlogPost) *BlogPost {
 
 func mapCU2IDs(contentUnits []*ContentUnit, db *sql.DB) (ids []int64, err error) {
 	cuids := make([]interface{}, len(contentUnits))
+	list := make([]string, len(contentUnits))
 	for idx, cu := range contentUnits {
 		cuids[idx] = cu.ID
+		list[idx] = string(cu.ID)
 	}
-	xus, err := mdbmodels.ContentUnits(db, qm.Select("id"), qm.WhereIn("uid in ?", cuids...), qm.OrderBy("created_at desc")).All()
+	mods := []qm.QueryMod{
+		qm.Select("id"),
+	}
+	if len(cuids) > 0 {
+		mods = append(mods, qm.WhereIn("uid in ?", cuids...))
+		// keep order of records exactly as in cuids
+		id_order := strings.Join(list, ",")
+		mods = append(mods, qm.InnerJoin("unnest('{" + id_order + "}'::varchar[]) WITH ORDINALITY t(uid, ord) USING(uid)"))
+		mods = append(mods, qm.OrderBy("t.ord"))
+	} else {
+		mods = append(mods, qm.OrderBy("created_at desc"))
+		mods = append(mods, qm.Limit(20))
+	}
+	xus, err := mdbmodels.ContentUnits(db, mods...).All()
 	if err != nil {
 		ids = []int64{}
 		return


### PR DESCRIPTION
2. Do not crash in case there are no units