### PR TITLE
mapping for typo suggest

### DIFF
--- a/data/es/mappings/grammars/grammars-am.json
+++ b/data/es/mappings/grammars/grammars-am.json
@@ -58,6 +58,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -92,6 +99,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/grammars/grammars-ar.json
+++ b/data/es/mappings/grammars/grammars-ar.json
@@ -58,6 +58,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -92,6 +99,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/grammars/grammars-bg.json
+++ b/data/es/mappings/grammars/grammars-bg.json
@@ -58,6 +58,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -92,6 +99,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/grammars/grammars-cs.json
+++ b/data/es/mappings/grammars/grammars-cs.json
@@ -58,6 +58,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -92,6 +99,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/grammars/grammars-de.json
+++ b/data/es/mappings/grammars/grammars-de.json
@@ -58,6 +58,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -92,6 +99,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/grammars/grammars-en.json
+++ b/data/es/mappings/grammars/grammars-en.json
@@ -59,6 +59,15 @@
             "number_of_replicas": 0, 
             "analysis": {
                 "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }, 
+                    "english_stemmer": {
+                        "type": "stemmer", 
+                        "language": "english"
+                    }, 
                     "english_stop": {
                         "stopwords": "_english_", 
                         "type": "stop"
@@ -67,10 +76,6 @@
                         "synonyms": [], 
                         "type": "synonym_graph", 
                         "tokenizer": "keyword"
-                    }, 
-                    "english_stemmer": {
-                        "type": "stemmer", 
-                        "language": "english"
                     }, 
                     "english_possessive_stemmer": {
                         "type": "stemmer", 
@@ -114,6 +119,13 @@
                     }
                 }, 
                 "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
+                    }, 
                     "english_synonym": {
                         "filter": [
                             "english_possessive_stemmer", 

--- a/data/es/mappings/grammars/grammars-es.json
+++ b/data/es/mappings/grammars/grammars-es.json
@@ -59,13 +59,18 @@
             "number_of_replicas": 0, 
             "analysis": {
                 "filter": {
-                    "spanish_stemmer": {
-                        "type": "stemmer", 
-                        "language": "light_spanish"
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
                     }, 
                     "spanish_stop": {
                         "stopwords": "_spanish_", 
                         "type": "stop"
+                    }, 
+                    "spanish_stemmer": {
+                        "type": "stemmer", 
+                        "language": "light_spanish"
                     }, 
                     "synonym_graph": {
                         "synonyms": [], 
@@ -110,6 +115,13 @@
                     }
                 }, 
                 "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
+                    }, 
                     "spanish_synonym": {
                         "filter": [
                             "lowercase", 

--- a/data/es/mappings/grammars/grammars-fa.json
+++ b/data/es/mappings/grammars/grammars-fa.json
@@ -58,6 +58,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -92,6 +99,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/grammars/grammars-fi.json
+++ b/data/es/mappings/grammars/grammars-fi.json
@@ -58,6 +58,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -92,6 +99,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/grammars/grammars-fr.json
+++ b/data/es/mappings/grammars/grammars-fr.json
@@ -58,6 +58,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -92,6 +99,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/grammars/grammars-he.json
+++ b/data/es/mappings/grammars/grammars-he.json
@@ -59,6 +59,11 @@
             "number_of_replicas": 0, 
             "analysis": {
                 "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }, 
                     "he_IL": {
                         "locale": "he_IL", 
                         "type": "hunspell", 
@@ -107,9 +112,15 @@
                     }
                 }, 
                 "analyzer": {
-                    "hebrew_synonym": {
+                    "typo_suggest": {
                         "filter": [
-                            "synonym_graph", 
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
+                    }, 
+                    "he": {
+                        "filter": [
                             "he_IL"
                         ], 
                         "char_filter": [
@@ -117,8 +128,9 @@
                         ], 
                         "tokenizer": "standard"
                     }, 
-                    "he": {
+                    "hebrew_synonym": {
                         "filter": [
+                            "synonym_graph", 
                             "he_IL"
                         ], 
                         "char_filter": [

--- a/data/es/mappings/grammars/grammars-hi.json
+++ b/data/es/mappings/grammars/grammars-hi.json
@@ -58,6 +58,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -92,6 +99,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/grammars/grammars-hr.json
+++ b/data/es/mappings/grammars/grammars-hr.json
@@ -58,6 +58,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -92,6 +99,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/grammars/grammars-hu.json
+++ b/data/es/mappings/grammars/grammars-hu.json
@@ -58,6 +58,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -92,6 +99,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/grammars/grammars-it.json
+++ b/data/es/mappings/grammars/grammars-it.json
@@ -58,6 +58,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -92,6 +99,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/grammars/grammars-ja.json
+++ b/data/es/mappings/grammars/grammars-ja.json
@@ -58,6 +58,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -92,6 +99,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/grammars/grammars-ka.json
+++ b/data/es/mappings/grammars/grammars-ka.json
@@ -58,6 +58,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -92,6 +99,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/grammars/grammars-lt.json
+++ b/data/es/mappings/grammars/grammars-lt.json
@@ -58,6 +58,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -92,6 +99,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/grammars/grammars-lv.json
+++ b/data/es/mappings/grammars/grammars-lv.json
@@ -58,6 +58,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -92,6 +99,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/grammars/grammars-mk.json
+++ b/data/es/mappings/grammars/grammars-mk.json
@@ -58,6 +58,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -92,6 +99,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/grammars/grammars-nl.json
+++ b/data/es/mappings/grammars/grammars-nl.json
@@ -58,6 +58,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -92,6 +99,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/grammars/grammars-no.json
+++ b/data/es/mappings/grammars/grammars-no.json
@@ -58,6 +58,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -92,6 +99,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/grammars/grammars-pl.json
+++ b/data/es/mappings/grammars/grammars-pl.json
@@ -58,6 +58,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -92,6 +99,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/grammars/grammars-pt.json
+++ b/data/es/mappings/grammars/grammars-pt.json
@@ -58,6 +58,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -92,6 +99,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/grammars/grammars-ro.json
+++ b/data/es/mappings/grammars/grammars-ro.json
@@ -58,6 +58,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -92,6 +99,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/grammars/grammars-ru.json
+++ b/data/es/mappings/grammars/grammars-ru.json
@@ -63,6 +63,11 @@
                         "type": "stemmer", 
                         "language": "russian"
                     }, 
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }, 
                     "synonym_graph": {
                         "synonyms": [], 
                         "type": "synonym_graph", 
@@ -110,6 +115,13 @@
                     }
                 }, 
                 "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
+                    }, 
                     "russian_synonym": {
                         "filter": [
                             "lowercase", 

--- a/data/es/mappings/grammars/grammars-sk.json
+++ b/data/es/mappings/grammars/grammars-sk.json
@@ -58,6 +58,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -92,6 +99,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/grammars/grammars-sl.json
+++ b/data/es/mappings/grammars/grammars-sl.json
@@ -58,6 +58,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -92,6 +99,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/grammars/grammars-sv.json
+++ b/data/es/mappings/grammars/grammars-sv.json
@@ -58,6 +58,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -92,6 +99,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/grammars/grammars-tr.json
+++ b/data/es/mappings/grammars/grammars-tr.json
@@ -58,6 +58,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -92,6 +99,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/grammars/grammars-ua.json
+++ b/data/es/mappings/grammars/grammars-ua.json
@@ -58,6 +58,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -92,6 +99,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/grammars/grammars-zh.json
+++ b/data/es/mappings/grammars/grammars-zh.json
@@ -58,6 +58,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -92,6 +99,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/results/results-am.json
+++ b/data/es/mappings/results/results-am.json
@@ -56,6 +56,10 @@
                 }, 
                 "content": {
                     "fields": {
+                        "suggest": {
+                            "type": "text", 
+                            "analyzer": "typo_suggest"
+                        }, 
                         "language": {
                             "type": "text", 
                             "analyzer": "standard"
@@ -94,6 +98,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -128,6 +139,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/results/results-ar.json
+++ b/data/es/mappings/results/results-ar.json
@@ -56,6 +56,10 @@
                 }, 
                 "content": {
                     "fields": {
+                        "suggest": {
+                            "type": "text", 
+                            "analyzer": "typo_suggest"
+                        }, 
                         "language": {
                             "type": "text", 
                             "analyzer": "arabic"
@@ -94,6 +98,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -128,6 +139,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/results/results-bg.json
+++ b/data/es/mappings/results/results-bg.json
@@ -56,6 +56,10 @@
                 }, 
                 "content": {
                     "fields": {
+                        "suggest": {
+                            "type": "text", 
+                            "analyzer": "typo_suggest"
+                        }, 
                         "language": {
                             "type": "text", 
                             "analyzer": "bulgarian"
@@ -94,6 +98,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -128,6 +139,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/results/results-cs.json
+++ b/data/es/mappings/results/results-cs.json
@@ -56,6 +56,10 @@
                 }, 
                 "content": {
                     "fields": {
+                        "suggest": {
+                            "type": "text", 
+                            "analyzer": "typo_suggest"
+                        }, 
                         "language": {
                             "type": "text", 
                             "analyzer": "czech"
@@ -94,6 +98,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -128,6 +139,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/results/results-de.json
+++ b/data/es/mappings/results/results-de.json
@@ -56,6 +56,10 @@
                 }, 
                 "content": {
                     "fields": {
+                        "suggest": {
+                            "type": "text", 
+                            "analyzer": "typo_suggest"
+                        }, 
                         "language": {
                             "type": "text", 
                             "analyzer": "german"
@@ -94,6 +98,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -128,6 +139,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/results/results-en.json
+++ b/data/es/mappings/results/results-en.json
@@ -56,6 +56,10 @@
                 }, 
                 "content": {
                     "fields": {
+                        "suggest": {
+                            "type": "text", 
+                            "analyzer": "typo_suggest"
+                        }, 
                         "language": {
                             "type": "text", 
                             "analyzer": "english_synonym"
@@ -95,6 +99,15 @@
             "number_of_replicas": 0, 
             "analysis": {
                 "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }, 
+                    "english_stemmer": {
+                        "type": "stemmer", 
+                        "language": "english"
+                    }, 
                     "english_stop": {
                         "stopwords": "_english_", 
                         "type": "stop"
@@ -103,10 +116,6 @@
                         "synonyms": [], 
                         "type": "synonym_graph", 
                         "tokenizer": "keyword"
-                    }, 
-                    "english_stemmer": {
-                        "type": "stemmer", 
-                        "language": "english"
                     }, 
                     "english_possessive_stemmer": {
                         "type": "stemmer", 
@@ -150,6 +159,13 @@
                     }
                 }, 
                 "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
+                    }, 
                     "english_synonym": {
                         "filter": [
                             "english_possessive_stemmer", 

--- a/data/es/mappings/results/results-es.json
+++ b/data/es/mappings/results/results-es.json
@@ -56,6 +56,10 @@
                 }, 
                 "content": {
                     "fields": {
+                        "suggest": {
+                            "type": "text", 
+                            "analyzer": "typo_suggest"
+                        }, 
                         "language": {
                             "type": "text", 
                             "analyzer": "spanish_synonym"
@@ -95,13 +99,18 @@
             "number_of_replicas": 0, 
             "analysis": {
                 "filter": {
-                    "spanish_stemmer": {
-                        "type": "stemmer", 
-                        "language": "light_spanish"
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
                     }, 
                     "spanish_stop": {
                         "stopwords": "_spanish_", 
                         "type": "stop"
+                    }, 
+                    "spanish_stemmer": {
+                        "type": "stemmer", 
+                        "language": "light_spanish"
                     }, 
                     "synonym_graph": {
                         "synonyms": [], 
@@ -146,6 +155,13 @@
                     }
                 }, 
                 "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
+                    }, 
                     "spanish_synonym": {
                         "filter": [
                             "lowercase", 

--- a/data/es/mappings/results/results-fa.json
+++ b/data/es/mappings/results/results-fa.json
@@ -56,6 +56,10 @@
                 }, 
                 "content": {
                     "fields": {
+                        "suggest": {
+                            "type": "text", 
+                            "analyzer": "typo_suggest"
+                        }, 
                         "language": {
                             "type": "text", 
                             "analyzer": "persian"
@@ -94,6 +98,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -128,6 +139,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/results/results-fi.json
+++ b/data/es/mappings/results/results-fi.json
@@ -56,6 +56,10 @@
                 }, 
                 "content": {
                     "fields": {
+                        "suggest": {
+                            "type": "text", 
+                            "analyzer": "typo_suggest"
+                        }, 
                         "language": {
                             "type": "text", 
                             "analyzer": "finnish"
@@ -94,6 +98,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -128,6 +139,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/results/results-fr.json
+++ b/data/es/mappings/results/results-fr.json
@@ -56,6 +56,10 @@
                 }, 
                 "content": {
                     "fields": {
+                        "suggest": {
+                            "type": "text", 
+                            "analyzer": "typo_suggest"
+                        }, 
                         "language": {
                             "type": "text", 
                             "analyzer": "french"
@@ -94,6 +98,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -128,6 +139,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/results/results-he.json
+++ b/data/es/mappings/results/results-he.json
@@ -56,6 +56,10 @@
                 }, 
                 "content": {
                     "fields": {
+                        "suggest": {
+                            "type": "text", 
+                            "analyzer": "typo_suggest"
+                        }, 
                         "language": {
                             "type": "text", 
                             "analyzer": "hebrew_synonym"
@@ -95,6 +99,11 @@
             "number_of_replicas": 0, 
             "analysis": {
                 "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }, 
                     "he_IL": {
                         "locale": "he_IL", 
                         "type": "hunspell", 
@@ -143,9 +152,15 @@
                     }
                 }, 
                 "analyzer": {
-                    "hebrew_synonym": {
+                    "typo_suggest": {
                         "filter": [
-                            "synonym_graph", 
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
+                    }, 
+                    "he": {
+                        "filter": [
                             "he_IL"
                         ], 
                         "char_filter": [
@@ -153,8 +168,9 @@
                         ], 
                         "tokenizer": "standard"
                     }, 
-                    "he": {
+                    "hebrew_synonym": {
                         "filter": [
+                            "synonym_graph", 
                             "he_IL"
                         ], 
                         "char_filter": [

--- a/data/es/mappings/results/results-hi.json
+++ b/data/es/mappings/results/results-hi.json
@@ -56,6 +56,10 @@
                 }, 
                 "content": {
                     "fields": {
+                        "suggest": {
+                            "type": "text", 
+                            "analyzer": "typo_suggest"
+                        }, 
                         "language": {
                             "type": "text", 
                             "analyzer": "hindi"
@@ -94,6 +98,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -128,6 +139,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/results/results-hr.json
+++ b/data/es/mappings/results/results-hr.json
@@ -56,6 +56,10 @@
                 }, 
                 "content": {
                     "fields": {
+                        "suggest": {
+                            "type": "text", 
+                            "analyzer": "typo_suggest"
+                        }, 
                         "language": {
                             "type": "text", 
                             "analyzer": "standard"
@@ -94,6 +98,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -128,6 +139,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/results/results-hu.json
+++ b/data/es/mappings/results/results-hu.json
@@ -56,6 +56,10 @@
                 }, 
                 "content": {
                     "fields": {
+                        "suggest": {
+                            "type": "text", 
+                            "analyzer": "typo_suggest"
+                        }, 
                         "language": {
                             "type": "text", 
                             "analyzer": "hungarian"
@@ -94,6 +98,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -128,6 +139,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/results/results-it.json
+++ b/data/es/mappings/results/results-it.json
@@ -56,6 +56,10 @@
                 }, 
                 "content": {
                     "fields": {
+                        "suggest": {
+                            "type": "text", 
+                            "analyzer": "typo_suggest"
+                        }, 
                         "language": {
                             "type": "text", 
                             "analyzer": "italian"
@@ -94,6 +98,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -128,6 +139,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/results/results-ja.json
+++ b/data/es/mappings/results/results-ja.json
@@ -56,6 +56,10 @@
                 }, 
                 "content": {
                     "fields": {
+                        "suggest": {
+                            "type": "text", 
+                            "analyzer": "typo_suggest"
+                        }, 
                         "language": {
                             "type": "text", 
                             "analyzer": "cjk"
@@ -94,6 +98,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -128,6 +139,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/results/results-ka.json
+++ b/data/es/mappings/results/results-ka.json
@@ -56,6 +56,10 @@
                 }, 
                 "content": {
                     "fields": {
+                        "suggest": {
+                            "type": "text", 
+                            "analyzer": "typo_suggest"
+                        }, 
                         "language": {
                             "type": "text", 
                             "analyzer": "standard"
@@ -94,6 +98,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -128,6 +139,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/results/results-lt.json
+++ b/data/es/mappings/results/results-lt.json
@@ -56,6 +56,10 @@
                 }, 
                 "content": {
                     "fields": {
+                        "suggest": {
+                            "type": "text", 
+                            "analyzer": "typo_suggest"
+                        }, 
                         "language": {
                             "type": "text", 
                             "analyzer": "lithuanian"
@@ -94,6 +98,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -128,6 +139,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/results/results-lv.json
+++ b/data/es/mappings/results/results-lv.json
@@ -56,6 +56,10 @@
                 }, 
                 "content": {
                     "fields": {
+                        "suggest": {
+                            "type": "text", 
+                            "analyzer": "typo_suggest"
+                        }, 
                         "language": {
                             "type": "text", 
                             "analyzer": "latvian"
@@ -94,6 +98,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -128,6 +139,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/results/results-mk.json
+++ b/data/es/mappings/results/results-mk.json
@@ -56,6 +56,10 @@
                 }, 
                 "content": {
                     "fields": {
+                        "suggest": {
+                            "type": "text", 
+                            "analyzer": "typo_suggest"
+                        }, 
                         "language": {
                             "type": "text", 
                             "analyzer": "standard"
@@ -94,6 +98,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -128,6 +139,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/results/results-nl.json
+++ b/data/es/mappings/results/results-nl.json
@@ -56,6 +56,10 @@
                 }, 
                 "content": {
                     "fields": {
+                        "suggest": {
+                            "type": "text", 
+                            "analyzer": "typo_suggest"
+                        }, 
                         "language": {
                             "type": "text", 
                             "analyzer": "dutch"
@@ -94,6 +98,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -128,6 +139,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/results/results-no.json
+++ b/data/es/mappings/results/results-no.json
@@ -56,6 +56,10 @@
                 }, 
                 "content": {
                     "fields": {
+                        "suggest": {
+                            "type": "text", 
+                            "analyzer": "typo_suggest"
+                        }, 
                         "language": {
                             "type": "text", 
                             "analyzer": "norwegian"
@@ -94,6 +98,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -128,6 +139,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/results/results-pl.json
+++ b/data/es/mappings/results/results-pl.json
@@ -56,6 +56,10 @@
                 }, 
                 "content": {
                     "fields": {
+                        "suggest": {
+                            "type": "text", 
+                            "analyzer": "typo_suggest"
+                        }, 
                         "language": {
                             "type": "text", 
                             "analyzer": "standard"
@@ -94,6 +98,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -128,6 +139,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/results/results-pt.json
+++ b/data/es/mappings/results/results-pt.json
@@ -56,6 +56,10 @@
                 }, 
                 "content": {
                     "fields": {
+                        "suggest": {
+                            "type": "text", 
+                            "analyzer": "typo_suggest"
+                        }, 
                         "language": {
                             "type": "text", 
                             "analyzer": "portuguese"
@@ -94,6 +98,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -128,6 +139,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/results/results-ro.json
+++ b/data/es/mappings/results/results-ro.json
@@ -56,6 +56,10 @@
                 }, 
                 "content": {
                     "fields": {
+                        "suggest": {
+                            "type": "text", 
+                            "analyzer": "typo_suggest"
+                        }, 
                         "language": {
                             "type": "text", 
                             "analyzer": "romanian"
@@ -94,6 +98,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -128,6 +139,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/results/results-ru.json
+++ b/data/es/mappings/results/results-ru.json
@@ -56,6 +56,10 @@
                 }, 
                 "content": {
                     "fields": {
+                        "suggest": {
+                            "type": "text", 
+                            "analyzer": "typo_suggest"
+                        }, 
                         "language": {
                             "type": "text", 
                             "analyzer": "russian_synonym"
@@ -98,6 +102,11 @@
                     "russian_stemmer": {
                         "type": "stemmer", 
                         "language": "russian"
+                    }, 
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
                     }, 
                     "synonym_graph": {
                         "synonyms": [], 
@@ -146,6 +155,13 @@
                     }
                 }, 
                 "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
+                    }, 
                     "russian_synonym": {
                         "filter": [
                             "lowercase", 

--- a/data/es/mappings/results/results-sk.json
+++ b/data/es/mappings/results/results-sk.json
@@ -56,6 +56,10 @@
                 }, 
                 "content": {
                     "fields": {
+                        "suggest": {
+                            "type": "text", 
+                            "analyzer": "typo_suggest"
+                        }, 
                         "language": {
                             "type": "text", 
                             "analyzer": "standard"
@@ -94,6 +98,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -128,6 +139,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/results/results-sl.json
+++ b/data/es/mappings/results/results-sl.json
@@ -56,6 +56,10 @@
                 }, 
                 "content": {
                     "fields": {
+                        "suggest": {
+                            "type": "text", 
+                            "analyzer": "typo_suggest"
+                        }, 
                         "language": {
                             "type": "text", 
                             "analyzer": "standard"
@@ -94,6 +98,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -128,6 +139,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/results/results-sv.json
+++ b/data/es/mappings/results/results-sv.json
@@ -56,6 +56,10 @@
                 }, 
                 "content": {
                     "fields": {
+                        "suggest": {
+                            "type": "text", 
+                            "analyzer": "typo_suggest"
+                        }, 
                         "language": {
                             "type": "text", 
                             "analyzer": "swedish"
@@ -94,6 +98,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -128,6 +139,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/results/results-tr.json
+++ b/data/es/mappings/results/results-tr.json
@@ -56,6 +56,10 @@
                 }, 
                 "content": {
                     "fields": {
+                        "suggest": {
+                            "type": "text", 
+                            "analyzer": "typo_suggest"
+                        }, 
                         "language": {
                             "type": "text", 
                             "analyzer": "turkish"
@@ -94,6 +98,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -128,6 +139,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/results/results-ua.json
+++ b/data/es/mappings/results/results-ua.json
@@ -56,6 +56,10 @@
                 }, 
                 "content": {
                     "fields": {
+                        "suggest": {
+                            "type": "text", 
+                            "analyzer": "typo_suggest"
+                        }, 
                         "language": {
                             "type": "text", 
                             "analyzer": "standard"
@@ -94,6 +98,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -128,6 +139,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/data/es/mappings/results/results-zh.json
+++ b/data/es/mappings/results/results-zh.json
@@ -56,6 +56,10 @@
                 }, 
                 "content": {
                     "fields": {
+                        "suggest": {
+                            "type": "text", 
+                            "analyzer": "typo_suggest"
+                        }, 
                         "language": {
                             "type": "text", 
                             "analyzer": "cjk"
@@ -94,6 +98,13 @@
         "index": {
             "number_of_replicas": 0, 
             "analysis": {
+                "filter": {
+                    "shingle": {
+                        "min_shingle_size": 2, 
+                        "type": "shingle", 
+                        "max_shingle_size": 3
+                    }
+                }, 
                 "char_filter": {
                     "quotes": {
                         "type": "mapping", 
@@ -128,6 +139,15 @@
                             "lowercase"
                         ], 
                         "type": "custom"
+                    }
+                }, 
+                "analyzer": {
+                    "typo_suggest": {
+                        "filter": [
+                            "lowercase", 
+                            "shingle"
+                        ], 
+                        "tokenizer": "standard"
                     }
                 }
             }, 

--- a/es/mappings/make.py
+++ b/es/mappings/make.py
@@ -315,12 +315,28 @@ def get_filters_imp(lang):
         return None
 
 
+def merge(lang, a, b):
+    b = b(lang)
+    if b:
+        a.update(b)
+
+    return a
+
+
 SETTINGS = {
     "index": {
         "number_of_shards": 1,
         "number_of_replicas": 0,
         "analysis": {
-            "analyzer": get_analyzer_imp,
+            "analyzer": lambda x: merge(x, {
+                "typo_suggest": {
+                    "tokenizer": "standard",
+                    "filter": [
+                        "lowercase",
+                        "shingle",
+                    ]
+                }
+            }, get_analyzer_imp),
             # "analyzer": {
             #      Tested, but didnt bring quality enough results:
             #     "phonetic_analyzer": {
@@ -362,7 +378,13 @@ SETTINGS = {
                     ],
                 },
             },
-            "filter": get_filters_imp,
+            "filter": lambda x: merge(x, {
+                "shingle": {
+                    "type": "shingle",
+                    "min_shingle_size": 2,
+                    "max_shingle_size": 3
+                },
+            }, get_filters_imp),
             # "filter": {
             #     "icu_transliterate": lambda lang: is_cyrillic(lang, {
             #       "type": "icu_transform",
@@ -465,6 +487,10 @@ RESULTS_TEMPLATE = {
                         "language": {
                             "type": "text",
                             "analyzer": lambda x: LANGUAGE_ANALYZER[x],
+                        },
+                        "suggest": {
+                            "type": "text",
+                            "analyzer": "typo_suggest",
                         },
                     },
                 },

--- a/search/typo_suggest_engine.go
+++ b/search/typo_suggest_engine.go
@@ -111,20 +111,20 @@ func (e *ESEngine) GetTypoSuggest(query Query, filterIntents []Intent) (null.Str
 		candidateField2.SetValid("content")
 		addMaxEdits = true
 	} else if hasRussian {
-		suggestorField = "content"
-		candidateField1.SetValid("content.language")
-		candidateField2.SetValid("title.language")
+		suggestorField = "content.suggest"
+		candidateField1.SetValid("content")
+		//candidateField2.SetValid("title.language")
 		addMaxEdits = false
 	} else if hasEnglish {
-		suggestorField = "content.language"
-		candidateField1.SetValid("content.language")
-		candidateField2 = null.StringFromPtr(nil)
+		suggestorField = "content.suggest"
+		candidateField1.SetValid("content")
+		//candidateField2 = null.StringFromPtr(nil)
 		addMaxEdits = true
 	} else {
 		//  default settings for all languages
-		suggestorField = "content.language"
-		candidateField1.SetValid("content.language")
-		candidateField2 = null.StringFromPtr(nil)
+		suggestorField = "content.suggest"
+		candidateField1.SetValid("content")
+		//candidateField2 = null.StringFromPtr(nil)
 		addMaxEdits = true
 	}
 
@@ -134,9 +134,13 @@ func (e *ESEngine) GetTypoSuggest(query Query, filterIntents []Intent) (null.Str
 		Text(checkTerm).
 		Field(suggestorField).
 		Size(1).
-		GramSize(1).
+		GramSize(3).
 		Confidence(1).
-		SmoothingModel(elastic.NewLaplaceSmoothingModel(0.7))
+		MaxErrors(3).
+		SmoothingModel(elastic.NewLaplaceSmoothingModel(0.7)).
+		CollateQuery(`{"match":{"{{field_name}}" : {"query": "{{suggestion}}","operator": "and"}}}`).
+		CollateParams(map[string]interface{}{"field_name": "content"}).
+		CollatePrune(false)
 
 	if candidateField1.Valid {
 		can1 := elastic.NewDirectCandidateGenerator(candidateField1.String).SuggestMode("popular")


### PR DESCRIPTION
customizing typo suggest

### tests fo current branch 
en
Not found suggests for known typos: 108 from 273.
Probable False Positive: 6 from 91.
Constant terms errors: 0. 

he
Not found suggests for known typos: 357 from 545.
Probable False Positive: 18 from 154.
Constant terms errors: 0. 

ru
Not found suggests for known typos: 50 from 65.
Probable False Positive: 19 from 111.
Constant terms errors: 0. 


### tests for master
ru
Not found suggests for known typos: 33 from 65.
Probable False Positive: 28 from 111.
Constant terms errors: 0. 

he
Not found suggests for known typos: 152 from 545.
Probable False Positive: 31 from 154.
Constant terms errors: 0. 

en
Not found suggests for known typos: 74 from 273.
Probable False Positive: 10 from 91.
Constant terms errors: 0. 
